### PR TITLE
refactor: 인기 동영상 DTO와 동영상 검색 DTO 분리 및 기존 코드와 연동

### DIFF
--- a/app/src/main/java/com/example/youtubeapi/data/model/dto/Video.kt
+++ b/app/src/main/java/com/example/youtubeapi/data/model/dto/Video.kt
@@ -1,11 +1,18 @@
 package com.example.youtubeapi.data.model.dto
 
-data class Video(
+data class HomeVideo(
+    val kind: String,
+    val etag: String,
+    val id: String,
+    val snippet: VideoSnippet,
+    val contentDetails: VideoContentDetails,
+)
+
+data class SearchVideo(
     val kind: String,
     val etag: String,
     val id: Id,
     val snippet: VideoSnippet,
-    val contentDetails: VideoContentDetails
 )
 
 data class Id(

--- a/app/src/main/java/com/example/youtubeapi/data/model/dto/VideoResponse.kt
+++ b/app/src/main/java/com/example/youtubeapi/data/model/dto/VideoResponse.kt
@@ -1,12 +1,12 @@
 package com.example.youtubeapi.data.model.dto
 
-data class VideoResponse(
+data class VideoResponse<T>(
     val kind: String,
     val etag: String,
     val nextPageToken: String,
     val regionCode: String,
     val pageInfo: PageInfo,
-    val items: List<Video>,
+    val items: List<T>,
 )
 
 data class PageInfo(

--- a/app/src/main/java/com/example/youtubeapi/data/remote/GoogleApiDataSource.kt
+++ b/app/src/main/java/com/example/youtubeapi/data/remote/GoogleApiDataSource.kt
@@ -1,6 +1,8 @@
 package com.example.youtubeapi.data.remote
 
 import com.example.youtubeapi.BuildConfig
+import com.example.youtubeapi.data.model.dto.HomeVideo
+import com.example.youtubeapi.data.model.dto.SearchVideo
 import com.example.youtubeapi.data.model.dto.VideoResponse
 import retrofit2.http.GET
 import retrofit2.http.Query
@@ -17,5 +19,51 @@ interface GoogleApiDataSource {
         @Query("maxWidth") maxWidth: Int,
         @Query("regionCode") regionCode: String = "KR",
         @Query("videoCategoryId") videoCategoryId: String,
-    ): VideoResponse
+    ): VideoResponse<HomeVideo>
+
+    /** 동영상 검색 API
+     *
+     * API 문서: https://developers.google.com/youtube/v3/docs/search/list?hl=ko#type
+     * 실사용: https://www.googleapis.com/youtube/v3/search?
+     *
+     * 검색 시, 필터나 정렬을 적용할 수 있는 쿼리 리스트업
+     * videoDefinition - 필터 (화질)
+     *    any - 해상도에 관계없이 모든 동영상을 반환합니다.
+     *    high – HD 동영상만 검색합니다.
+     *    standard – 표준 화질 동영상만 검색합니다.
+     *
+     *    * 위 속성을 쓸 경우 type 값으로 "video"를 전달해야함
+     *
+     * videoDuration - 필터 (영상 시간)
+     *    any – 동영상 길이를 기준으로 동영상 검색결과를 필터링하지 않습니다. 기본값입니다.
+     *    long – 20분보다 긴 동영상만 포함합니다.
+     *    medium – 4분 이상 20분 이하인 동영상만 포함합니다.
+     *    short – 4분 미만인 동영상만 포함합니다.
+     *
+     * videoCategoryId - 필터 (카테고리)
+     *    videoCategoryId 매개변수는 카테고리를 기준으로 동영상 검색결과를 필터링합니다.
+     *    이 매개변수의 값을 지정하는 경우 type 매개변수의 값도 video로 설정해야 합니다.
+     *
+     * order(기본값 relevance) - 정렬
+     *    date – 리소스를 만든 날짜를 기준으로 최근 항목부터 시간 순서대로 리소스를 정렬합니다.
+     *    rating – 높은 평점에서 낮은 평점순으로 리소스가 정렬됩니다.
+     *    relevance – 검색어와의 관련성을 기준으로 리소스를 정렬합니다. 이 매개변수의 기본값입니다.
+     *    title – 제목에 따라 알파벳순으로 리소스를 정렬합니다.
+     *    videoCount – 업로드된 동영상 수에 따라 채널을 내림차순으로 정렬합니다.
+     *    viewCount – 리소스가 조회수가 높은 순에서 낮은 순으로 정렬됩니다. 실시간 방송의 경우 시청자 수를 기준으로 동영상이 정렬됩니다.
+     *
+     *
+     */
+    @GET("youtube/v3/search")
+    suspend fun getSearchVideo(
+        @Query("key") key: String = BuildConfig.GOOGLE_API_KEY,
+        @Query("q") query: String, // 검색어
+        @Query("maxResults") maxResults: Int,
+        @Query("videoDefinition") videoDefinition: String,
+        @Query("type") type: String = "video", // video, channel, playlist
+        @Query("part") part: String = "snippet",
+        @Query("regionCode") regionCode: String = "KR",
+        // @Query("relevanceLanguage") relevanceLanguage: String = "KR", // 지정된 언어와 가장 관련성이 높은 검색결과를 반환
+
+    ): VideoResponse<SearchVideo>
 }

--- a/app/src/main/java/com/example/youtubeapi/presentation/uistate/VideoState.kt
+++ b/app/src/main/java/com/example/youtubeapi/presentation/uistate/VideoState.kt
@@ -1,7 +1,8 @@
 package com.example.youtubeapi.presentation.uistate
 
+import com.example.youtubeapi.data.model.dto.HomeVideo
+import com.example.youtubeapi.data.model.dto.SearchVideo
 import com.example.youtubeapi.data.model.dto.Thumbnail
-import com.example.youtubeapi.data.model.dto.Video
 
 data class VideoState(
     val id: String,
@@ -9,21 +10,30 @@ data class VideoState(
     val description: String,
     val channelTitle: String,
     val thumbnail: Thumbnail,
-    val duration: String,
-    val categoryId: String,
+    val duration: String = "",
+    val categoryId: String = "",
     val publishedAt: String,
 )
 
 /**
  * thumbnail resolution default
  * */
-fun Video.asVideoState() = VideoState(
-    id = id.videoId,
+fun HomeVideo.asVideoState() = VideoState(
+    id = id,
     title = snippet.title,
     description = snippet.description,
     channelTitle = snippet.channelTitle,
     thumbnail = snippet.thumbnails.default,
     duration = contentDetails.duration,
     categoryId = snippet.categoryId,
+    publishedAt = snippet.publishedAt
+)
+
+fun SearchVideo.asVideoState() = VideoState(
+    id = id.videoId,
+    title = snippet.title,
+    description = snippet.description,
+    channelTitle = snippet.channelTitle,
+    thumbnail = snippet.thumbnails.default,
     publishedAt = snippet.publishedAt
 )


### PR DESCRIPTION
```kotlin
data class HomeVideo(
    val kind: String,
    val etag: String,
    val id: String,
    val snippet: VideoSnippet,
    val contentDetails: VideoContentDetails,
)

data class SearchVideo(
    val kind: String,
    val etag: String,
    val id: Id,
    val snippet: VideoSnippet,
)
```

- DTO에서 id 및 contentDetails 파라미터가 불일치 하여 DTO를 분리했습니다.
- 같은 VideoResponse에 2가지 DTO를 같이 사용하기 위해 제네릭을 적용했습니다.