### PR TITLE
feat: Room getAllVideoEntity의 리턴 타입을 flow로 변경

### DIFF
--- a/app/src/main/java/com/example/youtubeapi/data/local/dao/VideoEntityDao.kt
+++ b/app/src/main/java/com/example/youtubeapi/data/local/dao/VideoEntityDao.kt
@@ -5,11 +5,12 @@ import androidx.room.Delete
 import androidx.room.Insert
 import androidx.room.Query
 import com.example.youtubeapi.data.model.entity.VideoEntity
+import kotlinx.coroutines.flow.Flow
 
 @Dao
 interface VideoEntityDao {
     @Query("SELECT * FROM VideoEntity")
-    fun getAllVideoEntity(): List<VideoEntity>
+    fun getAllVideoEntity(): Flow<List<VideoEntity>>
     @Delete
     fun deleteVideoEntity(videoEntity: VideoEntity)
     @Insert

--- a/app/src/main/java/com/example/youtubeapi/viewmodel/MainViewModel.kt
+++ b/app/src/main/java/com/example/youtubeapi/viewmodel/MainViewModel.kt
@@ -1,7 +1,38 @@
 package com.example.youtubeapi.viewmodel
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import com.example.youtubeapi.data.local.dao.VideoEntityDao
+import com.example.youtubeapi.data.model.entity.VideoEntity
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
 
-class MainViewModel: ViewModel() {
+class MainViewModel(
+    private val videoEntityDao: VideoEntityDao
+): ViewModel() {
 
+    private val _bookmarks = MutableStateFlow(listOf<VideoEntity>())
+    val bookmarks = _bookmarks.asStateFlow()
+
+    init {
+        initBookmarks()
+    }
+
+    private fun initBookmarks() {
+        viewModelScope.launch {
+            videoEntityDao.getAllVideoEntity().collect {
+                _bookmarks.value = it
+            }
+        }
+    }
+}
+
+class MainViewModelFactory(
+    private val videoEntityDao: VideoEntityDao
+): ViewModelProvider.Factory {
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+        return MainViewModel(videoEntityDao) as T
+    }
 }


### PR DESCRIPTION
Room getAllVideoEntity의 리턴 타입을 flow로 변경하여 table 변화를 관찰하도록 하였습니다.
emit 값을 MainViewModel에서 읽을 수 있도록 bookmarks stateflow를 생성하여 초기화시에 관찰을 수행하도록 했습니다.
Dao를 viewModel에서 사용하기 위해서 MainViewModel 파라미터로 videoEntityDao를 추가해 주고 이에 따라서 viewModel factory를 변경했습니다.