### PR TITLE
refactor: detail 페이지 안쓰는 채널 UI 제거 및 교체. 게시일 regex 처리

### DIFF
--- a/app/src/main/java/com/example/youtubeapi/presentation/fragment/VideoDetailFragment.kt
+++ b/app/src/main/java/com/example/youtubeapi/presentation/fragment/VideoDetailFragment.kt
@@ -108,9 +108,8 @@ class VideoDetailFragment : Fragment() {
                                 }
                                 tvTitle.text = videoStates[0].title
                                 tvChannel.text = videoStates[0].channelTitle
-                                ivChannelProfile.load(videoStates[0].thumbnail.url) //우선 섬네일 넣어뒀는데 채널 사진으로 바꾸어야 됨. 갖고 올 수 있는 건가???
-                                tvSubscribers.text =
-                                    videoStates[0].channelTitle // 채널 구독자 수 확인하려면 채널 API 사용해야 함.
+//                                ivChannelProfile.load(videoStates[0].thumbnail.url) //우선 섬네일 넣어뒀는데 채널 사진으로 바꾸어야 됨. 갖고 올 수 있는 건가???
+                                tvSubscribers.text = isoDateToKor(videoStates[0].publishedAt) // 채널 구독자 수 확인하려면 채널 API 사용해야 함.
                                 tvDescription.text = videoStates[0].description
                             }
                         }
@@ -171,4 +170,19 @@ class VideoDetailFragment : Fragment() {
 
 
 }
+private fun isoDateToKor(isoDate: String): String {
+    val regex = Regex("(\\d{4})-(\\d{2})-(\\d{2})T(\\d{2}):(\\d{2}):(\\d{2})Z")
+    val matchResult = regex.find(isoDate)
 
+    if (matchResult != null) {
+        val (year, month, day, hour, minute) = matchResult.destructured
+
+        val hourInt = hour.toInt()
+        val period = if (hourInt >= 12) "PM" else "AM"
+        val hour12 = if (hourInt > 12) hourInt - 12 else if (hourInt == 0) 12 else hourInt
+
+        val formattedDate = "게시일: ${year}년 ${month}월 ${day}일 ${hour12}:${minute}${period}"
+        return formattedDate
+    } else
+    { return "" }
+}

--- a/app/src/main/res/layout/fragment_video_detail.xml
+++ b/app/src/main/res/layout/fragment_video_detail.xml
@@ -71,42 +71,33 @@
         app:layout_constraintStart_toStartOf="@id/tv_title"
         android:layout_marginLeft="@dimen/default_horizontal_margin16"
         android:layout_marginRight="@dimen/default_horizontal_margin16"
-        android:layout_marginTop="@dimen/default_horizontal_margin8"
+        android:layout_marginTop="@dimen/default_horizontal_margin12"
         android:layout_marginBottom="@dimen/default_horizontal_margin8"
         android:gravity="center_vertical">
-        <androidx.cardview.widget.CardView
-            android:id="@+id/cv_channel_profile"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            app:cardCornerRadius="28dp">
-            <ImageView
-                android:id="@+id/iv_channel_profile"
-                android:layout_width="56dp"
-                android:layout_height="56dp"
-                app:layout_constraintTop_toBottomOf="@id/tv_title"
-                android:background="@drawable/img_profile_test"/>
-        </androidx.cardview.widget.CardView>
+
         <LinearLayout
             android:layout_width="wrap_content"
             android:layout_height="match_parent"
             android:orientation="vertical"
             android:gravity="center_vertical">
+
+            <TextView
+                android:id="@+id/tv_subscribers"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="영상 업로드 날짜"
+                android:textSize="16dp"
+                android:layout_marginLeft="@dimen/default_horizontal_margin8"
+                android:textColor="@color/whitish_grey"/>
             <TextView
                 android:id="@+id/tv_channel"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="채널명"
-                android:textSize="18dp"
+                android:textSize="20dp"
+                android:textStyle="bold"
                 android:layout_marginLeft="@dimen/default_horizontal_margin8"
                 android:textColor="@color/white"/>
-            <TextView
-                android:id="@+id/tv_subscribers"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="구독자 수"
-                android:textSize="16dp"
-                android:layout_marginLeft="@dimen/default_horizontal_margin8"
-                android:textColor="@color/whitish_grey"/>
         </LinearLayout>
         <View
             android:layout_width="0dp"


### PR DESCRIPTION
### 구현한 기능
 VideoDetailFragment에서는 새로 channel api 불러오지 않기로 해서,
- 사용하지 않는 채널 썸네일 ImageView 제거
- 채널명, 구독자 수 TextView를 영상 게시일, 채널명으로 각각 수정
- isoDateToKor 함수에서 raw date "0000년 00월 00일 00:00AM" 꼴로 수정

### 구현 이미지
<img src="https://github.com/3-6-advanced-project/Y-Media/assets/75528131/2e9d65ac-0e1e-432f-aa02-d34d38fe8af4" width="300"> <img src="https://github.com/3-6-advanced-project/Y-Media/assets/75528131/fff8befc-df6f-49b0-8091-dcf6b55c1997" width="300">


